### PR TITLE
Opt in to AVIF images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,5 +2,7 @@ const { i18n } = require("./next-i18next.config");
 
 module.exports = {
   i18n,
-  webpack5: true,
+  images: {
+    formats: ["image/avif", "image/webp"],
+  },
 };

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps, InferGetStaticPropsType } from "next";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import DishList from "../components/DishList";
@@ -29,7 +29,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 export default function Search({
   searchTerm,
   results,
-}: InferGetStaticPropsType<typeof getServerSideProps>) {
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { t } = useTranslation("common");
   return (
     <>


### PR DESCRIPTION
This can lead to up to 20% smaller image downloads, which can make a
huge difference on image-heavy pages like the homepage or the "all
recipes" page.

This closes #74