### PR TITLE
fix: don't trigger search on empty input

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -83,7 +83,7 @@ const SearchBar = ({ placeholder }: Props) => {
     debounce(fetchSearchResults, 250, {
       maxWait: 1500,
     }),
-    [searchTerm]
+    []
   );
 
   useEffect(() => {
@@ -108,6 +108,11 @@ const SearchBar = ({ placeholder }: Props) => {
   }
 
   async function fetchSearchResults(searchTerm: string) {
+    if (searchTerm === "") {
+      setSearchResults([]);
+      return;
+    }
+    console.log("Fetching search results for", searchTerm);
     const results = await (
       await fetch(`/api/search?query=${searchTerm}`, {
         headers: {

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -28,6 +28,9 @@ export async function searchRecipes(
   language: SupportedLanguage,
   searchTerm: string
 ) {
+  if (!searchTerm) {
+    return [];
+  }
   const recipes = await fetchRecipeIndex(language);
   const fuse = new Fuse(recipes, searchOptions);
 


### PR DESCRIPTION
This commit add a base case to both the search input and the search API
endpoint. Both now have a short-cut for returning no search results when
the search term is empty.

This fixes #276.
